### PR TITLE
Gutemberg Support and popup archives remove

### DIFF
--- a/popups.php
+++ b/popups.php
@@ -35,12 +35,12 @@ define( 'SPU_PLUGIN_DIR' , plugin_dir_path(__FILE__) );
 define( 'SPU_PLUGIN_URL' , plugin_dir_url(__FILE__) );
 define( 'SPU_PLUGIN_HOOK' , basename( dirname( __FILE__ ) ) . '/' . basename( __FILE__ ) );
 
-require_once( plugin_dir_path( __FILE__ ) . 'admin/includes/class-spu-upgrader.php' );
-require_once( plugin_dir_path( __FILE__ ) . 'public/class-social-popup.php' );
+require_once( SPU_PLUGIN_DIR . 'admin/includes/class-spu-upgrader.php' );
+require_once( SPU_PLUGIN_DIR . 'public/class-social-popup.php' );
 // Include Helper class
 require_once( SPU_PLUGIN_DIR . 'includes/class-spu-helper.php' );
 // Dependencies
-require_once( plugin_dir_path( __FILE__ ) . 'vendor/autoload.php' );
+require_once( SPU_PLUGIN_DIR . 'vendor/autoload.php' );
 
 /*
  * Register hooks that are fired when the plugin is activated or deactivated.

--- a/public/class-social-popup.php
+++ b/public/class-social-popup.php
@@ -281,15 +281,15 @@ class SocialPopup {
 		);
 
 		$args = array(
-			'labels'             => $labels,
-			'public'             => true,
-			'publicly_queryable' => true,
-			'show_ui'            => true,
-			'show_in_menu'       => true,
-			'query_var'          => true,
-			'rewrite'            => array( 'slug' => 'spucpt' ),
-			'capability_type'    => 'post',
-			'capabilities' => array(
+			'labels'				=> $labels,
+			'public'				=> true,
+			'publicly_queryable'	=> true,
+			'show_ui'				=> true,
+			'show_in_menu'			=> true,
+			'query_var'				=> true,
+			'rewrite'				=> array( 'slug' => 'spucpt' ),
+			'capability_type'		=> 'post',
+			'capabilities'			=> array(
 				'publish_posts' 		=> apply_filters( 'spu/settings_page/roles', 'manage_options'),
 				'edit_posts' 			=> apply_filters( 'spu/settings_page/roles', 'manage_options'),
 				'edit_others_posts' 	=> apply_filters( 'spu/settings_page/roles', 'manage_options'),
@@ -300,11 +300,12 @@ class SocialPopup {
 				'delete_post' 			=> apply_filters( 'spu/settings_page/roles', 'manage_options'),
 				'read_post' 			=> apply_filters( 'spu/settings_page/roles', 'manage_options'),
 			),
-			'has_archive'        => true,
-			'hierarchical'       => false,
-			'menu_position'      => null,
-			'menu_icon'				 => 'dashicons-share-alt',
-			'supports'           => array( 'title', 'editor','author' )
+			'has_archive'			=> false,
+			'hierarchical'			=> false,
+			'menu_position'			=> null,
+			'menu_icon'				=> 'dashicons-share-alt',
+			'supports'				=> array( 'title', 'editor','author' ),
+			'show_in_rest'	=> true
 		);
 
 		register_post_type( 'spucpt', $args );


### PR DESCRIPTION
-Gutenberg Support: New WP editor support. 
-Popup´s archive removed: post_type register change in ('has_archive'=>false) to remove popups to the public view.